### PR TITLE
Fix sibling consumer worker 48262801

### DIFF
--- a/app/workers/sibling_consumer.rb
+++ b/app/workers/sibling_consumer.rb
@@ -5,7 +5,7 @@ class SiblingConsumer
   def self.perform
     Rails.logger.info "Starting sibling consumption..."
 
-    Sibling.consume
+    Sibling.consume_main_app_hcard
 
     Rails.logger.info "Succeeded consuming siblings."
   rescue StandardError => e

--- a/spec/workers/sibling_consumer_spec.rb
+++ b/spec/workers/sibling_consumer_spec.rb
@@ -3,11 +3,18 @@ require "spec_helper"
 describe SiblingConsumer do
   describe ".perform" do
     it "consumes entry feed" do
-      Sibling.should_receive(:consume).once
+      Sibling.should_receive(:consume_main_app_hcard).once
       SiblingConsumer.perform
     end
+    it "raises error when there is no Sibling.main_app_uid" do
+      lambda { SiblingConsumer.perform }.should raise_error(TypeError)
+    end
+    it "returns true when there is a Sibling.main_app_uid" do
+      Sibling.stub(:main_app_uid).and_return("spec/support/g5-configurator-app.html")
+      SiblingConsumer.perform.should be_true
+    end
     it "does not swallow errors" do
-      Sibling.stub(:consume).and_raise(StandardError.new("Foo"))
+      Sibling.stub(:consume_main_app_hcard).and_raise(StandardError.new("Foo"))
       lambda { SiblingConsumer.perform }.should raise_error(StandardError, "Foo")
     end
   end


### PR DESCRIPTION
``` bash
undefined method `consume' for #<Class:0x00000004a9c190>
/app/vendor/bundle/ruby/1.9.1/gems/activerecord-3.2.13/lib/active_record/dynamic_matchers.rb:55:in `method_missing'
/app/vendor/bundle/ruby/1.9.1/gems/g5_sibling_deployer_engine-0.2.2/app/workers/sibling_consumer.rb:8:in `perform'
```

uses correct method in worker and adds better specs
