### PR TITLE
Fix template errors

### DIFF
--- a/app/views/siblings/index.html.erb
+++ b/app/views/siblings/index.html.erb
@@ -24,7 +24,7 @@
         <td>
           <%= link_to 'UID', t.uid, class: "btn" %>
           <% unless t.main_app? %>
-            <%= link_to "Deploy", deploy_sibling_path(t), class: "btn", method: post %>
+            <%= link_to "Deploy", deploy_sibling_path(t), class: "btn", method: :post %>
           <% end %>
         </td>
       </tr>


### PR DESCRIPTION
I am hoping this fixes an error I am getting on Heroku.

```
Apr 30 12:26:00 g5-cau-6d4gqkl-demo app/web.1:    vendor/bundle/ruby/2.1.0/gems/actionview-4.1.0/lib/action_view/renderer/renderer.rb:42:in `render_template' 
Apr 30 12:26:00 g5-cau-6d4gqkl-demo app/web.1:    vendor/bundle/ruby/2.1.0/gems/actionview-4.1.0/lib/action_view/renderer/renderer.rb:23:in `render' 
Apr 30 12:26:00 g5-cau-6d4gqkl-demo app/web.1:    vendor/bundle/ruby/2.1.0/gems/actionview-4.1.0/lib/action_view/rendering.rb:99:in `_render_template' 
Apr 30 12:26:00 g5-cau-6d4gqkl-demo app/web.1:    vendor/bundle/ruby/2.1.0/gems/actionpack-4.1.0/lib/action_controller/metal/streaming.rb:217:in `_render_template' 
Apr 30 12:26:00 g5-cau-6d4gqkl-demo app/web.1:    vendor/bundle/ruby/2.1.0/gems/actionview-4.1.0/lib/action_view/rendering.rb:82:in `render_to_body' 
Apr 30 12:26:00 g5-cau-6d4gqkl-demo app/web.1:    vendor/bundle/ruby/2.1.0/gems/actionpack-4.1.0/lib/action_controller/metal/rendering.rb:32:in `render_to_body' 
Apr 30 12:26:00 g5-cau-6d4gqkl-demo app/web.1:    vendor/bundle/ruby/2.1.0/gems/actionpack-4.1.0/lib/action_controller/metal/renderers.rb:32:in `render_to_body' 
Apr 30 12:26:00 g5-cau-6d4gqkl-demo app/web.1:    vendor/bundle/ruby/2.1.0/gems/actionpack-4.1.0/lib/abstract_controller/rendering.rb:25:in `render' 
Apr 30 12:26:00 g5-cau-6d4gqkl-demo app/web.1:    vendor/bundle/ruby/2.1.0/gems/actionpack-4.1.0/lib/action_controller/metal/rendering.rb:16:in `render' 
Apr 30 12:26:00 g5-cau-6d4gqkl-demo app/web.1:    vendor/bundle/ruby/2.1.0/gems/actionpack-4.1.0/lib/action_controller/metal/instrumentation.rb:41:in `block (2 levels) in render' 
Apr 30 12:26:00 g5-cau-6d4gqkl-demo app/web.1:    vendor/bundle/ruby/2.1.0/gems/activesupport-4.1.0/lib/active_support/core_ext/benchmark.rb:12:in `block in ms' 
Apr 30 12:26:00 g5-cau-6d4gqkl-demo app/web.1:    Rendered vendor/bundle/ruby/2.1.0/gems/g5_sibling_deployer_engine-0.4.0/app/views/siblings/_nav.html.erb (2.0ms) 
Apr 30 12:26:00 g5-cau-6d4gqkl-demo app/web.1:  Completed 500 Internal Server Error in 114ms
```

These paths work
http://g5-cau-6d4gqkl-demo.herokuapp.com/siblings/instructions
http://g5-cau-6d4gqkl-demo.herokuapp.com/siblings/deploys

But index doesn't
http://g5-cau-6d4gqkl-demo.herokuapp.com/siblings

The paths that work reference the partial by `"siblings/nav"`
